### PR TITLE
refactor(base): remove legacy hack for svg strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vizabi-ws-reader",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Vizabi WS reader",
   "main": "dist/bundle.js",
   "repository": {

--- a/src/ws-reader-type-base.js
+++ b/src/ws-reader-type-base.js
@@ -153,7 +153,6 @@ function WsReaderBase () {
 
     _readCallbackSuccessDone: function(vPromise, path, query, resp) {
       //cache and resolve
-      this._addShapes(path, query, resp);
       FILE_CACHED[path] = resp;
       this._parse(vPromise, query, resp);
       FILE_REQUESTED[path] = void 0;
@@ -185,21 +184,6 @@ function WsReaderBase () {
         'data': path
       });
     },
-
-    _addShapes: function(path, query, respReady) {
-      if(path.indexOf('entities') > -1) {
-        let keyHolder = query.key ? query.key : query.select.key;
-        let prefixKey = keyHolder[0];
-        _.map(respReady, row => {
-          for(let keyEntity in row) {
-            if (keyEntity.indexOf("shape") > -1) {
-              let currValue = row[keyEntity];
-              row[keyEntity] = "<svg xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 584.5 364.5'><path id='" + row[prefixKey] + "' d='" + currValue + "'/></svg>";
-            }
-          }
-        });
-      }
-    }
 
   };
 }


### PR DESCRIPTION
vizabi can handle both, bare paths and svgs, no need for an adaptor