### PR TITLE
chore(general): refactoring

### DIFF
--- a/src/index-node.js
+++ b/src/index-node.js
@@ -5,8 +5,7 @@ import * as ReaderUtils from './reader-utils-node';
 export const WsReader = {
   getReader(... readerPlugins) {
     const backendRequestAdapter = { ajax: ReaderUtils.ajax };
-    const backendHomepointAdapter = { getHref: () => null };
-    const BaseWsReader = getBaseWsReader(backendRequestAdapter, backendHomepointAdapter);
+    const BaseWsReader = getBaseWsReader(backendRequestAdapter);
 
     Object.assign(BaseWsReader, ... readerPlugins);
 

--- a/src/index-web.js
+++ b/src/index-web.js
@@ -5,8 +5,7 @@ import * as ReaderUtils from './reader-utils-web';
 export const WsReader = {
   getReader(... readerPlugins) {
     const webRequestAdapter = { ajax: ReaderUtils.ajax };
-    const webHomepointAdapter = { getHref: () => window.location.href };
-    const BaseWsReader = getBaseWsReader(webRequestAdapter, webHomepointAdapter);
+    const BaseWsReader = getBaseWsReader(webRequestAdapter);
 
     Object.assign(BaseWsReader, ... readerPlugins);
 

--- a/src/reader-utils-node.js
+++ b/src/reader-utils-node.js
@@ -1,5 +1,7 @@
 const fetch = require('node-fetch-polyfill');
 
+import { WsError, NETWORK_RESPONSE_ERROR, UNEXPECTED_ERROR } from './ws-error';
+
 function ajax(options = {}) {
   const { url = '', json = false } = options;
 
@@ -12,8 +14,9 @@ function ajax(options = {}) {
   return fetch(url, { method: 'GET', headers })
     .then(response => {
       if (!response.ok) {
-        throw Error(response.statusText);
+        throw new WsError(NETWORK_RESPONSE_ERROR, response.statusText);
       }
+
       return response;
     })
     .then(response => {
@@ -21,6 +24,13 @@ function ajax(options = {}) {
         return response.json();
       }
       return response.text();
+    })
+    .catch(error => {
+      if (error instanceof WsError) {
+        throw error;
+      } else {
+        throw new WsError(UNEXPECTED_ERROR, error);
+      }
     });
 }
 

--- a/src/reader-utils-web.js
+++ b/src/reader-utils-web.js
@@ -1,5 +1,7 @@
 import 'whatwg-fetch';
 
+import { WsError, NETWORK_RESPONSE_ERROR, UNEXPECTED_ERROR } from './ws-error';
+
 function ajax(options = {}) {
   const { url = '', json = false } = options;
 
@@ -12,8 +14,9 @@ function ajax(options = {}) {
   return fetch(url, { method: 'GET', headers })
     .then(response => {
       if (!response.ok) {
-        throw Error(response.statusText);
+        throw new WsError(NETWORK_RESPONSE_ERROR, response.statusText);
       }
+
       return response;
     })
     .then(response => {
@@ -21,6 +24,13 @@ function ajax(options = {}) {
         return response.json();
       }
       return response.text();
+    })
+    .catch(error => {
+      if (error instanceof WsError) {
+        throw error;
+      } else {
+        throw new WsError(UNEXPECTED_ERROR, error);
+      }
     });
 }
 

--- a/src/ws-error.js
+++ b/src/ws-error.js
@@ -1,0 +1,18 @@
+export const NETWORK_RESPONSE_ERROR = 'Network response error';
+export const UNEXPECTED_ERROR = 'Unexpected error';
+export const WS_BAD_RESPONSE = 'WS bad response';
+export const WS_ERROR = 'WS error';
+export const WS_MESSAGE = 'WS message';
+
+export class WsError {
+  constructor(type, details) {
+    this.type = type;
+    this.details = details;
+  }
+
+  valueOf() {
+    const offset = 2;
+
+    return `${this.type}: ${JSON.stringify(this.details, null, offset)}`;
+  }
+}

--- a/test/reader-utils.spec.js
+++ b/test/reader-utils.spec.js
@@ -108,7 +108,7 @@ describe('RowUtils', () => {
       });
 
       return ReaderUtils.ajax().catch(error => {
-        expect(error.message).to.equal('Boo!');
+        expect(error.valueOf()).to.equal('Network response error: "Boo!"');
       });
     }));
 

--- a/test/ws-reader.spec.js
+++ b/test/ws-reader.spec.js
@@ -260,7 +260,6 @@ describe('WsReader', () => {
     afterEach(() => sandbox.restore());
 
     it('rejects response when request to the server failed', () => {
-      const expectedLocationHref = 'http://localhost:4200/tools/#_sgdfh=12324&_dfdf=fgsd';
       const wsReaderConfig = {
         path: 'http://localhost:3000/',
         dataset: 'open-numbers/globalis#development'
@@ -271,22 +270,19 @@ describe('WsReader', () => {
       const wsReader = WsReader.getReader();
 
       wsReader.init(wsReaderConfig);
-      sandbox.stub(wsReader, '_getWindowLocationHref').returns(expectedLocationHref);
 
       return wsReader.read({}).catch(error => {
         expect(error).to.deep.equal({
           error: 'Response is incorrect',
           data: {
             ddfql: { dataset: 'open-numbers%2Fglobalis%23development' },
-            endpoint: `${wsReaderConfig.path}?_dataset=open-numbers%252Fglobalis%2523development`,
-            homepoint: expectedLocationHref
+            endpoint: `${wsReaderConfig.path}?_dataset=open-numbers%252Fglobalis%2523development`
           }
         });
       });
     });
 
     it('dataset from query have first priority', () => {
-      const expectedLocationHref = 'http://localhost:4200/tools/#_sgdfh=12324&_dfdf=fgsd';
       const wsReaderConfig = {
         path: 'http://localhost:3000/',
         dataset: 'open-numbers/globalis#development'
@@ -297,22 +293,19 @@ describe('WsReader', () => {
       const wsReader = WsReader.getReader();
 
       wsReader.init(wsReaderConfig);
-      sandbox.stub(wsReader, '_getWindowLocationHref').returns(expectedLocationHref);
 
       return wsReader.read({ dataset: 'other-open-numbers/globalis#development' }).catch(error => {
         expect(error).to.deep.equal({
           error: 'Response is incorrect',
           data: {
             ddfql: { dataset: 'other-open-numbers%2Fglobalis%23development' },
-            endpoint: `${wsReaderConfig.path}?_dataset=other-open-numbers%252Fglobalis%2523development`,
-            homepoint: expectedLocationHref
+            endpoint: `${wsReaderConfig.path}?_dataset=other-open-numbers%252Fglobalis%2523development`
           }
         });
       });
     });
 
     it('query without token & reads data successfully', () => {
-      const expectedLocationHref = 'http://localhost:4200/tools/#_sgdfh=12324&_dfdf=fgsd';
       const wsReaderConfig = {
         path: 'http://localhost:3000/',
         dataset: 'open-numbers/globalis#development'
@@ -332,7 +325,6 @@ describe('WsReader', () => {
       const wsReader = WsReader.getReader();
 
       wsReader.init(wsReaderConfig);
-      sandbox.stub(wsReader, '_getWindowLocationHref').returns(expectedLocationHref);
 
       const parsedResponse = [
         {
@@ -376,7 +368,6 @@ describe('WsReader', () => {
     });
 
     it('query with token & reads data successfully', () => {
-      const expectedLocationHref = 'http://localhost:4200/tools/#_sgdfh=12324&_dfdf=fgsd';
       const wsReaderConfig = {
         dataset_access_token: '123',
         path: 'http://localhost:3000/',
@@ -396,7 +387,6 @@ describe('WsReader', () => {
       const wsReader = WsReader.getReader();
 
       wsReader.init(wsReaderConfig);
-      sandbox.stub(wsReader, '_getWindowLocationHref').returns(expectedLocationHref);
 
       const parsedResponse = [
         {
@@ -440,7 +430,6 @@ describe('WsReader', () => {
     });
 
     it('returns an error if response came in the incorrect format', () => {
-      const expectedLocationHref = 'http://localhost:4200/tools/#_sgdfh=12324&_dfdf=fgsd';
       const wsReaderConfig = {
         path: 'http://localhost:3000/',
         dataset: 'open-numbers/globalis#development'
@@ -452,7 +441,6 @@ describe('WsReader', () => {
       const wsReader = WsReader.getReader();
 
       wsReader.init(wsReaderConfig);
-      sandbox.stub(wsReader, '_getWindowLocationHref').returns(expectedLocationHref);
 
       return wsReader.read({ from: 'datapoints' }).catch(error => {
         expect(error).to.deep.equal({
@@ -461,19 +449,14 @@ describe('WsReader', () => {
               from: 'datapoints',
               dataset: 'open-numbers%2Fglobalis%23development'
             },
-            endpoint: `${wsReaderConfig.path}?_from=datapoints&dataset=open-numbers%252Fglobalis%2523development`,
-            homepoint: expectedLocationHref
+            endpoint: `${wsReaderConfig.path}?_from=datapoints&dataset=open-numbers%252Fglobalis%2523development`
           },
-          error: {
-            data: 'incorrect',
-            message: 'Bad Response: incorrect'
-          }
+          error: { error: 'WS bad response: "incorrect"' }
         });
       });
     });
 
     it('encodes dataset provided in the ddfql query', () => {
-      const expectedLocationHref = 'http://localhost:4200/tools/#_sgdfh=12324&_dfdf=fgsd';
       const wsReaderConfig = {
         path: 'http://localhost:3000/',
         dataset: 'open-numbers/globalis#development'
@@ -491,7 +474,6 @@ describe('WsReader', () => {
       const wsReader = WsReader.getReader();
 
       wsReader.init(wsReaderConfig);
-      sandbox.stub(wsReader, '_getWindowLocationHref').returns(expectedLocationHref);
 
       return wsReader.read(query).then(() => {
         sinon.assert.calledOnce(ajaxStub);


### PR DESCRIPTION
remove all plugins from WS-Reader
create on Vizabi Events for listening to them in WS-Reader by @angie
improve error handling on WS-Reader (timeouts, responses from WS with messages and errors, etc) - Vizabi will watch on a Promise that WS-Reader returns and throws an error in case of a rejection
GA callbacks in VTP will listen to Vizabi events (not WS-Reader) by @angie
WS-Reader shouldn’t support hooks that we were used before for GA tracking, all of them should be on Vizabi

Closes #18